### PR TITLE
Support node 10.2 and refactor to be more reusable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ env:
   global:
     - REPO=steadyserv/node
   matrix:
-    - VERSION=9.0-alpine TAG=alpine TAG=latest MAJOR=9
+    - VERSION=10.2-alpine TAG=alpine TAG=latest MAJOR=10
+    - VERSION=9.0-alpine TAG=alpine MAJOR=9
     - VERSION=8.3-alpine MAJOR=8
     - VERSION=8.2-alpine
     - VERSION=8.1-alpine
@@ -26,5 +27,6 @@ before_script:
   - env | sort
   - cd "$VERSION"
   - export IMAGE="${REPO}:${VERSION}"
+  - ../.travis/dependencies.sh
 
 script: ../.travis/build.sh

--- a/.travis/dependencies.sh
+++ b/.travis/dependencies.sh
@@ -1,0 +1,1 @@
+docker build -t dumb-init:1.2.0 ../dumb-init

--- a/10.2-alpine/Dockerfile
+++ b/10.2-alpine/Dockerfile
@@ -1,0 +1,23 @@
+ARG NODE_VERSION=10.2.1-alpine
+ARG DUMB_INIT_VERSION=1.2.0
+
+# Reference dumb-init so we can copy it over
+FROM dumb-init:${DUMB_INIT_VERSION} as DUMB_INIT
+
+FROM node:${NODE_VERSION}
+
+# Add dumb-init for proper PID 1 management
+COPY --from=DUMB_INIT dumb-init /usr/bin/dumb-init
+
+# Add su-exec for easy step-down from root
+RUN apk add --no-cache su-exec
+
+# Exclude npm cache from the image
+VOLUME /root/.npm
+
+WORKDIR /app
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["node"]

--- a/10.2-alpine/entrypoint.sh
+++ b/10.2-alpine/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/dumb-init /bin/sh
+set -e
+
+# allow the container to be started with `--user`
+# all node/npm commands should be dropped to the correct user
+if [ "$1" = "node" ] || [ "$1" = "npm" ] && [ "$(id -u)" = '0' ]; then
+  chown -R node:node /app
+  exec su-exec node "$0" "$@"
+fi
+
+exec "$@"

--- a/dumb-init/Dockerfile
+++ b/dumb-init/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.7 as DUMB_INIT
+ARG DUMB_INIT_VERSION=1.2.0
+RUN apk add --no-cache --virtual .install-deps openssl
+RUN wget https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_amd64
+RUN wget https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/sha256sums
+RUN grep dumb-init_${DUMB_INIT_VERSION}_amd64$ sha256sums | sha256sum -c
+RUN mv dumb-init_${DUMB_INIT_VERSION}_amd64 dumb-init
+RUN chmod +x dumb-init


### PR DESCRIPTION
The refactor includes:

- breaking the dumb-init steps out into their own image so the result can easily be copied into another container
- adding a step before the build to create the dumb-init image. This can be cached since you should only need to download it once
- The node and dumb-init versions can be passed as args. This could potentially make supporting new versions much simpler since you'd only need to add to the matrix in .travis. The build.sh script would need to be changed to handle this.